### PR TITLE
cleanup up bash-completion 

### DIFF
--- a/bash/.bash_completion
+++ b/bash/.bash_completion
@@ -1,0 +1,62 @@
+#!/bin/bash -l
+
+#  ---------------------------------------------------------------------------
+#
+#  ______      _  ______ _ _           
+#  |  _  \    | | |  ___(_) |          
+#  | | | |___ | |_| |_   _| | ___  ___ 
+#  | | | / _ \| __|  _| | | |/ _ \/ __|
+#  | |/ / (_) | |_| |   | | |  __/\__ \
+#  |___/ \___/ \__\_|   |_|_|\___||___/
+#                                                                            
+#  Description:  Mac OS X Dotfiles - Simply designed to fit your shell life.
+#  																			
+#  Sections:																
+#  																			
+#  	1.  Bash Completion
+#	2.	Bash Completion@2
+#
+#  ---------------------------------------------------------------------------
+
+
+#  ---------------------------------------------------------------------------
+#   1. Bash Completion
+#  ---------------------------------------------------------------------------
+
+# set bash completion for support of macOS and brew bash versions (V 3+)
+# this requires the 'bash-completion' brew install 
+
+if [ -f /usr/local/etc/bash_completion ]; then
+   . /usr/local/etc/bash_completion
+fi
+
+
+#  ---------------------------------------------------------------------------
+#   2. Bash Completion@2
+#  ---------------------------------------------------------------------------
+
+# NB. If using completion@2 you need to be aware of a few things:
+# 1. its not compatible with the previous version so you will need to run the folling if its installed
+# 		brew remove bash-completion 
+# 2. Brew bash installed v4.1+ is required, run the following if its not already installed. 
+# 		brew install bash 
+# 3. Install bash-completion@2
+#  		brew install bash-completion@2
+# 4. Default bash needs to be changed to brew bash version
+# 		# Add the new shell to the list of allowed shells do not un-comment thiese lines in this file
+# 		sudo bash -c 'echo /usr/local/bin/bash >> /etc/shells'
+# 		# Change to the new shell
+# 		chsh -s /usr/local/bin/bash 
+# 5. Comment out the Section '1. Bash Completion' and uncomment the following 3 lines
+ 
+# if [ -f /usr/local/share/bash-completion/bash_completion ]; then
+#     . /usr/local/share/bash-completion/bash_completion
+# fi
+
+
+
+
+
+
+
+

--- a/bash/.bash_completion
+++ b/bash/.bash_completion
@@ -13,7 +13,7 @@
 #  																			
 #  Sections:																
 #  																			
-#  	1.  Bash Completion
+#  	1.	Bash Completion
 #	2.	Bash Completion@2
 #
 #  ---------------------------------------------------------------------------

--- a/bash/.bash_profile
+++ b/bash/.bash_profile
@@ -467,3 +467,11 @@ if [ -f "$HOME/exec -l /bin/bash/google-cloud-sdk/completion.bash.inc" ]; then s
 #export PATH="$(brew --prefix)/opt/curl/bin:$PATH"
 # shellcheck disable=SC1090
 [[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm" # Load RVM into a shell session *as a function*
+
+# Perl notes
+# By default non-brewed cpan modules are installed to the Cellar. If you wish
+# for your modules to persist across updates we recommend using `local::lib`.
+
+# You can set that up like this:
+#   PERL_MM_OPT="INSTALL_BASE=$HOME/perl5" cpan local::lib
+#   echo 'eval "$(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib=$HOME/perl5)"' >> ~/.bash_profile

--- a/bash/.bash_profile
+++ b/bash/.bash_profile
@@ -471,7 +471,6 @@ if [ -f "$HOME/exec -l /bin/bash/google-cloud-sdk/completion.bash.inc" ]; then s
 # Perl notes
 # By default non-brewed cpan modules are installed to the Cellar. If you wish
 # for your modules to persist across updates we recommend using `local::lib`.
-
 # You can set that up like this:
 #   PERL_MM_OPT="INSTALL_BASE=$HOME/perl5" cpan local::lib
 #   echo 'eval "$(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib=$HOME/perl5)"' >> ~/.bash_profile

--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -22,3 +22,8 @@ fi
 if [ -f ~/.bash_aliases ]; then
   source ~/.bash_aliases
 fi
+
+# Source the .bash_completion file.
+if [ -f ~/.bash_completion ]; then
+  source ~/.bash_completion
+fi

--- a/homebrew/brewfile.sh
+++ b/homebrew/brewfile.sh
@@ -63,7 +63,8 @@ brew install automake
 brew install awscli
 brew install axel
 brew install bash
-brew install bash-completion@2
+brew install bash-completion
+#brew install bash-completion@2 ## Further setup required. see .bash_completion file
 brew install bfg
 brew install binutils
 brew install binwalk
@@ -260,23 +261,6 @@ brew install xz
 brew install yarn
 brew install youtube-dl
 brew install zsh
-
-##########################################
-# Properly setting up bash
-##########################################
-# Homebrew's install of bash sets it up in your $PATH as with most brew installs, however 
-# it does not change your user shell to use the new bash install
-# This can cause errors, for example when adding bash-completion@2 to your .bash_pofile
-# The following sets up brew bash your user shell 
-# This does require sudo and your user password
-# This change can be descrutive so the below is commented out and you can add in as required or do not use completion@2:
-# see here for details - https://github.com/Homebrew/homebrew-core/issues/25370
-
-# # Add the new shell to the list of allowed shells
-# sudo bash -c 'echo /usr/local/bin/bash >> /etc/shells'
-# # Change to the new shell
-# chsh -s /usr/local/bin/bash 
-
 
 ##########################################
 # Add softwares

--- a/homebrew/brewfile.sh
+++ b/homebrew/brewfile.sh
@@ -294,7 +294,7 @@ brew cask install chefdk
 brew cask install cleanmymac
 brew cask install cocoapods-app
 brew cask install codekit
-brew cask install colorpicker
+# brew cask install colorpicker ## removing, not found on install
 brew cask install colorsnapper
 brew cask install coteditor
 brew cask install docker

--- a/homebrew/brewfile.sh
+++ b/homebrew/brewfile.sh
@@ -378,6 +378,7 @@ brew cask install vagrant
 brew cask install vagrant-manager
 brew cask install versions
 brew cask install virtualbox
+brew cask install virtualbox-extension-pack
 brew cask install visual-studio-code
 brew cask install vlc
 brew cask install webpquicklook

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reedia-dotfiles",
-    "version": "0.1.65",
+    "version": "0.1.67",
     "description": "Dotfiles - A set of Mac OS X configuration files - Simply designed to fit your shell life.",
     "keywords": [
         "dotfiles",


### PR DESCRIPTION
These changes revert back to the standard bash-completion setup which support both the brew bash and macOS bash versions

There is a new .bash_completion file which is sourced if appropriate
Details and instructions for setting up bash-completion@2 is also in this file if you wish to use it.