### PR TITLE
updates to bashrc 

### DIFF
--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -23,7 +23,7 @@ if [ -f ~/.bash_aliases ]; then
   source ~/.bash_aliases
 fi
 
-# Source the .bash_completion file.
-if [ -f ~/.bash_completion ]; then
+# Source the .bash_load_completion file.
+if [ -f ~/.bash_load_completion ]; then
   source ~/.bash_load_completion
 fi

--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -25,5 +25,5 @@ fi
 
 # Source the .bash_completion file.
 if [ -f ~/.bash_completion ]; then
-  source ~/.bash_completion
+  source ~/.bash_load_completion
 fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reedia-dotfiles",
-    "version": "0.1.69",
+    "version": "0.1.71",
     "description": "Dotfiles - A set of Mac OS X configuration files - Simply designed to fit your shell life.",
     "keywords": [
         "dotfiles",


### PR DESCRIPTION
fixes link to .bash_load_completion
Sorry missed this on last pull request :(